### PR TITLE
Update README link to point to current website homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Monopoly (2-4 players)
 
 
 
-To play the game, please head to http://ambersong.me/Game .
+To play the game, please head to http://ambersong.me/ .


### PR DESCRIPTION
The README link (http://ambersong.me/Game) currently returns a blank page. The updated link points towards the current sites homepage (http://ambersong.me/).