### PR TITLE
Remove ioutil

### DIFF
--- a/findAirplane.go
+++ b/findAirplane.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -577,7 +577,7 @@ func airplaneGameHandler(w http.ResponseWriter, r *http.Request) {
 	// Check if it is post or get
 	if r.Method == http.MethodPost {
 		//	if post, get new data, update it and then send the data back
-		reqBody, err := ioutil.ReadAll(r.Body)
+		reqBody, err := io.ReadAll(r.Body)
 		logError(err)
 		var receiveGame AirplaneGame
 		err = json.Unmarshal(reqBody, &receiveGame)

--- a/server.go
+++ b/server.go
@@ -3,10 +3,10 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 )
@@ -147,7 +147,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	b, err := ioutil.ReadFile("frontend/dist/index.html")
+	b, err := os.ReadFile("frontend/dist/index.html")
 	logError(err)
 	w.Write(b)
 }

--- a/tictactoebox.go
+++ b/tictactoebox.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -198,7 +198,7 @@ func tictactoeBoxGameHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method == http.MethodPost {
-		reqBody, err := ioutil.ReadAll(r.Body)
+		reqBody, err := io.ReadAll(r.Body)
 		logError(err)
 
 		var getPost TicTacToeBoxRound


### PR DESCRIPTION
Go's ioutil package is depreciated since Go 1.16. The functionality has been replaced by os.ReadFile and io.ReadAll.

Tested by playing a game of airplane using the network code, such that the io.ReadAll was called. Not sure if the os.ReadFile call is used any more but ported it over just in case.